### PR TITLE
Fix bullet points under(3. Expected Behavior) in the code-of-conduct.md

### DIFF
--- a/about/code-of-conduct.md
+++ b/about/code-of-conduct.md
@@ -40,15 +40,11 @@ If‭ ‬you‭ ‬see‭ ‬someone‭ ‬who‭ ‬is‭ ‬making‭ ‬an‭
 
 ### 3.‎ ‏Expected‭ ‬Behavior
 
- * Participate‭ ‬in‭ ‬an‭ ‬authentic‭ ‬and‭ ‬active‭ ‬way.‭ ‬In‭ ‬doing‭ ‬so,‭
- * ‬you‭ ‬contribute‭ ‬to‭ ‬the‭ ‬health‭ ‬and‭ ‬longevity‭ ‬of‭ ‬this‭
- * ‬community. Exercise‭ ‬consideration‭ ‬and‭ ‬respect‭ ‬in‭ ‬your‭ ‬speech‭
- * ‬and‭ ‬actions. Attempt‭ ‬collaboration‭ ‬before‭ ‬conflict. Refrain‭ ‬from‭
- * ‬demeaning,‭ ‬discriminatory,‭ ‬or‭ ‬harassing‭ ‬behavior‭ ‬and‭ ‬speech.
- * Be‭ ‬mindful‭ ‬of‭ ‬your‭ ‬surroundings‭ ‬and‭ ‬of‭ ‬your‭ ‬fellow‭
- * ‬participants.‭ ‬Alert‭ ‬community‭ ‬leaders‭ ‬if‭ ‬you‭ ‬notice‭ ‬a‭
- * ‬dangerous‭ ‬situation,‭ ‬someone‭ ‬in‭ ‬distress,‭ ‬or‭ ‬violations‭ ‬of‭
- * ‬this‭ ‬Code‭ ‬of‭ ‬Conduct,‭ ‬even‭ ‬if‭ ‬they‭ ‬seem‭ ‬inconsequential.
+ * Participate‭ ‬in‭ ‬an‭ ‬authentic‭ ‬and‭ ‬active‭ ‬way.‭ ‬In‭ ‬doing‭ ‬so you‭ ‬contribute‭ ‬to‭ ‬the‭ ‬health‭ ‬and‭ longevity‭ ‬of‭ ‬this‭ community. 
+ * Exercise‭ ‬consideration‭ ‬and‭ ‬respect‭ ‬in‭ ‬your‭ ‬speech‭ and‭ ‬actions. 
+ * Attempt‭ ‬collaboration‭ ‬before‭ ‬conflict. Refrain‭ ‬from‭ demeaning,‭ ‬discriminatory,‭ ‬or‭ ‬harassing‭ ‬behavior‭ ‬and‭ ‬speech.
+ * Be‭ ‬mindful‭ ‬of‭ ‬your‭ ‬surroundings‭ ‬and‭ ‬of‭ ‬your‭ ‬fellow‭ participants.‭
+ * ‬Alert‭ ‬community‭ ‬leaders‭ ‬if‭ ‬you‭ ‬notice‭ ‬a‭ dangerous‭ ‬situation,‭ ‬someone‭ ‬in‭ ‬distress,‭ ‬or‭ ‬violations‭ of‭ this‭ ‬Code‭ ‬of‭ ‬Conduct,‭ ‬even‭ ‬if‭ ‬they‭ ‬seem‭ ‬inconsequential.
 
 ### 4.‎ ‏Unacceptable‭ ‬Behavior
 


### PR DESCRIPTION
The bullet points under section 3(Expected Behavoir) were incorrect and words from one point were overflowing to the next bullet point.